### PR TITLE
Fixes warnings from attach terms-to-posts

### DIFF
--- a/src/Attach_Command.php
+++ b/src/Attach_Command.php
@@ -46,7 +46,16 @@ class Attach_Command {
 		$progress = Utils\make_progress_bar( sprintf( 'Attaching terms from the taxonomy "%s" for the post type "%s"', $assoc_args['taxonomy'], $assoc_args['post_type'] ), $assoc_args['count'] );
 
 		foreach( $post_ids as $post_id ) {
-			$random_term_ids = array_values( array_intersect_key( $term_ids, array_flip( array_rand( $term_ids, mt_rand( 0, 4 ) ) ) ) );
+			$number_of_terms = mt_rand( 0, 4 );
+			if ( $number_of_terms > 1 ) {
+				$random_terms = array_rand( $term_ids, $number_of_terms );
+			} elseif ( 1 === $number_of_terms ) {
+				$random_terms = array( array_rand( $term_ids, 1 ) );
+			} else {
+				$random_terms = array();
+			}
+
+			$random_term_ids = array_values( array_intersect_key( $term_ids, array_flip( $random_terms ) ) );
 			$terms = wp_set_object_terms( $post_id, $random_term_ids, $assoc_args['taxonomy'] );
 
 			$progress->tick();


### PR DESCRIPTION
The current way the terms are attached to posts can lead to a bunch of errors:

```
Warning: array_flip() expects parameter 1 to be array, int given in /Users/msaari/.wp-cli/packages/vendor/wpastronaut/wp-cli-seeder/src/Attach_Command.php on line 49
Warning: array_intersect_key(): Expected parameter 2 to be an array, null given in /Users/msaari/.wp-cli/packages/vendor/wpastronaut/wp-cli-seeder/src/Attach_Command.php on line 49
Warning: array_values() expects parameter 1 to be array, null given in /Users/msaari/.wp-cli/packages/vendor/wpastronaut/wp-cli-seeder/src/Attach_Command.php on line 49
Warning: array_rand(): Second argument has to be between 1 and the number of elements in the array in /Users/msaari/.wp-cli/packages/vendor/wpastronaut/wp-cli-seeder/src/Attach_Command.php on line 49
```

and

```
Warning: array_flip() expects parameter 1 to be array, int given in /Users/msaari/.wp-cli/packages/vendor/wpastronaut/wp-cli-seeder/src/Attach_Command.php on line 49
Warning: array_intersect_key(): Expected parameter 2 to be an array, null given in /Users/msaari/.wp-cli/packages/vendor/wpastronaut/wp-cli-seeder/src/Attach_Command.php on line 49
Warning: array_values() expects parameter 1 to be array, null given in /Users/msaari/.wp-cli/packages/vendor/wpastronaut/wp-cli-seeder/src/Attach_Command.php on line 49
Warning: array_rand(): Second argument has to be between 1 and the number of elements in the array in /Users/msaari/.wp-cli/packages/vendor/wpastronaut/wp-cli-seeder/src/Attach_Command.php on line 49
```

and so on. The cause of this is the way `array_rand()` is used here. First of all, `array_rand()` expects a value between 1 and the number of elements in the array, so trying to use it with a value of 0 causes a warning and a NULL return value. So, if `mt_rand( 0, 4 )` returns zero, instead of using `array_rand()` to get a NULL value, the code should just create an empty array.

Also, when `array_rand()` returns one item from the array, it returns an int and not an array, leading to `array_flip() expects parameter 1 to be array, int given` errors.

I broke up the neat one-liner into many more lines, but now it works without errors. If the random number is over 1, the process works as before. If the random number is 1, the return value from `array_rand()` is converted to an array and if the random number is 0, an empty array is created.